### PR TITLE
Add `keywords` field to `SeoFieldGroup` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tager/admin-ui",
-  "version": "0.8.59",
+  "version": "0.8.60",
   "license": "MIT",
   "main": "dist/index.esm.js",
   "module": "dist/index.esm.js",

--- a/src/components/SeoFieldGroup/SeoFieldGroup.stories.ts
+++ b/src/components/SeoFieldGroup/SeoFieldGroup.stories.ts
@@ -20,6 +20,7 @@ const TEST_FILE: SingleFileInputValueType = {
 interface ValuesState {
   pageTitle: string;
   pageDescription: string;
+  keywords: string;
   openGraphImage: SingleFileInputValueType | null;
 }
 
@@ -31,12 +32,14 @@ export const Default = () =>
       const values = ref<ValuesState>({
         pageTitle: 'title',
         pageDescription: 'description',
+        keywords: 'keywords',
         openGraphImage: TEST_FILE,
       });
 
       function handleSearchEngineOptimization({
         title,
         description,
+        keywords,
         image,
       }: SeoChangeEvent) {
         // values.value.pageTitle = title;
@@ -54,6 +57,10 @@ export const Default = () =>
         values.value.pageDescription = value;
       }
 
+      function handleSEOKeywords(value: string) {
+        values.value.keywords = value;
+      }
+
       function handleSEOImage(value: SingleFileInputValueType | null) {
         values.value.openGraphImage = value;
       }
@@ -62,6 +69,7 @@ export const Default = () =>
         values,
         handleSEOTitle,
         handleSEODescription,
+        handleSEOKeywords,
         handleSEOImage,
         handleSearchEngineOptimization,
       };
@@ -72,6 +80,11 @@ export const Default = () =>
         @change:title="handleSEOTitle"
         :description="values.pageDescription"
         @change:description="handleSEODescription"
+
+        :should-display-keywords="true"
+        :keywords="values.keywords"
+        @change:keywords="handleSEOKeywords"
+        
         :image="values.openGraphImage"
         @change:image="handleSEOImage"
         @change="handleSearchEngineOptimization"

--- a/src/components/SeoFieldGroup/SeoFieldGroup.vue
+++ b/src/components/SeoFieldGroup/SeoFieldGroup.vue
@@ -6,7 +6,7 @@
       :error="titleErrorMessage"
       :min="50"
       :max="60"
-      name="pageTitle"
+      :name="titleName"
       @input="handleTitleChange"
     />
 
@@ -17,16 +17,27 @@
       :min="115"
       :max="165"
       type="textarea"
-      name="pageDescription"
+      :name="descriptionName"
       @input="handleDescriptionChange"
     />
 
+    <FormField
+      v-if="shouldDisplayKeywords"
+      :value="keywords"
+      :label="computedKeywordsLabel"
+      :error="keywordsErrorMessage"
+      :name="keywordsName"
+      @input="handleKeywordsChange"
+    />
+
     <FormFieldFileInput
+      v-if="shouldDisplayImage"
       :value="image"
       :label="computedImageLabel"
       :error="imageErrorMessage"
       file-type="image"
-      name="openGraphImage"
+      :name="imageName"
+      :scenario="imageScenario"
       @change="handleImageChange"
     />
   </div>
@@ -36,6 +47,7 @@
 import { computed, defineComponent, SetupContext } from '@vue/composition-api';
 import { SeoChangeEvent, SingleFileInputValueType } from '../../typings/common';
 
+import FormField from '../FormField';
 import FormFieldRecommendedLengthInput from '../FormFieldRecommendedLengthInput';
 import FormFieldFileInput from '../FormFieldFileInput';
 import useTranslation from '../../hooks/useTranslation';
@@ -43,18 +55,35 @@ import useTranslation from '../../hooks/useTranslation';
 interface Props {
   titleLabel: string;
   title: string;
+  titleName: string;
   titleErrorMessage: string;
+
   descriptionLabel: string;
   description: string;
+  descriptionName: string;
   descriptionErrorMessage: string;
+
+  shouldDisplayKeywords: boolean;
+  keywordsLabel: string;
+  keywords: string;
+  keywordsName: string;
+  keywordsErrorMessage: string;
+
+  shouldDisplayImage: boolean;
   imageLabel: string;
   image: SingleFileInputValueType | null;
+  imageName: string;
+  imageScenario: string | null;
   imageErrorMessage: string;
 }
 
 export default defineComponent<Props>({
   name: 'SeoFieldGroup',
-  components: { FormFieldRecommendedLengthInput, FormFieldFileInput },
+  components: {
+    FormFieldRecommendedLengthInput,
+    FormFieldFileInput,
+    FormField,
+  },
   props: {
     titleLabel: {
       type: String,
@@ -64,10 +93,15 @@ export default defineComponent<Props>({
       type: String,
       default: '',
     },
+    titleName: {
+      type: String,
+      default: 'pageTitle',
+    },
     titleErrorMessage: {
       type: String,
       default: '',
     },
+
     descriptionLabel: {
       type: String,
       default: '',
@@ -76,9 +110,39 @@ export default defineComponent<Props>({
       type: String,
       default: '',
     },
+    descriptionName: {
+      type: String,
+      default: 'pageDescription',
+    },
     descriptionErrorMessage: {
       type: String,
       default: '',
+    },
+
+    shouldDisplayKeywords: {
+      type: Boolean,
+      default: false,
+    },
+    keywordsLabel: {
+      type: String,
+      default: '',
+    },
+    keywords: {
+      type: String,
+      default: '',
+    },
+    keywordsName: {
+      type: String,
+      default: 'keywords',
+    },
+    keywordsErrorMessage: {
+      type: String,
+      default: '',
+    },
+
+    shouldDisplayImage: {
+      type: Boolean,
+      default: true,
     },
     imageLabel: {
       type: String,
@@ -88,6 +152,14 @@ export default defineComponent<Props>({
       type: Object,
       default: null,
     },
+    imageName: {
+      type: String,
+      default: 'openGraphImage',
+    },
+    imageScenario: {
+      type: String,
+      default: null,
+    },
     imageErrorMessage: {
       type: String,
       default: '',
@@ -95,31 +167,6 @@ export default defineComponent<Props>({
   },
   setup(props: Props, context: SetupContext) {
     const { t } = useTranslation(context);
-
-    function handleTitleChange(value: string) {
-      context.emit('change:title', value);
-      emitChangeEvent({ title: value });
-    }
-
-    function handleDescriptionChange(value: string) {
-      context.emit('change:description', value);
-      emitChangeEvent({ description: value });
-    }
-
-    function handleImageChange(value: SingleFileInputValueType | null) {
-      context.emit('change:image', value);
-      emitChangeEvent({ image: value });
-    }
-
-    function emitChangeEvent(event: Partial<SeoChangeEvent>) {
-      const value: SeoChangeEvent = {
-        title: props.title,
-        description: props.description,
-        image: props.image,
-        ...event,
-      };
-      context.emit('change', value);
-    }
 
     const computedTitleLabel = computed(() => {
       if (props.titleLabel) {
@@ -135,6 +182,13 @@ export default defineComponent<Props>({
       return t('ui:seoFieldGroup.pageDescription');
     });
 
+    const computedKeywordsLabel = computed(() => {
+      if (props.keywordsLabel) {
+        return props.keywordsLabel;
+      }
+      return t('ui:seoFieldGroup.keywords');
+    });
+
     const computedImageLabel = computed(() => {
       if (props.imageLabel) {
         return props.imageLabel;
@@ -142,12 +196,45 @@ export default defineComponent<Props>({
       return t('ui:seoFieldGroup.openGraphImage');
     });
 
+    function emitChangeEvent(event: Partial<SeoChangeEvent>) {
+      const value: SeoChangeEvent = {
+        title: props.title,
+        description: props.description,
+        keywords: props.keywords,
+        image: props.image,
+        ...event,
+      };
+      context.emit('change', value);
+    }
+
+    function handleTitleChange(value: string) {
+      context.emit('change:title', value);
+      emitChangeEvent({ title: value });
+    }
+
+    function handleDescriptionChange(value: string) {
+      context.emit('change:description', value);
+      emitChangeEvent({ description: value });
+    }
+
+    function handleKeywordsChange(value: string) {
+      context.emit('change:keywords', value);
+      emitChangeEvent({ keywords: value });
+    }
+
+    function handleImageChange(value: SingleFileInputValueType | null) {
+      context.emit('change:image', value);
+      emitChangeEvent({ image: value });
+    }
+
     return {
       computedTitleLabel,
       computedDescriptionLabel,
+      computedKeywordsLabel,
       computedImageLabel,
       handleTitleChange,
       handleDescriptionChange,
+      handleKeywordsChange,
       handleImageChange,
     };
   },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -36,6 +36,7 @@ const EN = {
   seoFieldGroup: {
     pageTitle: 'Page title',
     pageDescription: 'Page description',
+    keywords: 'Keywords',
     openGraphImage: 'Open graph image',
   },
 

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -38,6 +38,7 @@ const RU: typeof EN = {
   seoFieldGroup: {
     pageTitle: 'Заголовок страницы',
     pageDescription: 'Описание страницы',
+    keywords: 'Ключевые слова',
     openGraphImage: 'Картинка страницы',
   },
 

--- a/src/typings/common.ts
+++ b/src/typings/common.ts
@@ -256,6 +256,7 @@ export type SingleFileInputValueType = {
 export interface SeoChangeEvent {
   title: string;
   description: string;
+  keywords: string;
   image: SingleFileInputValueType | null;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -464,6 +464,7 @@ export declare function useCopyToClipboard(
 export interface SeoChangeEvent {
   title: string;
   description: string;
+  keywords: string;
   image: SingleFileInputValueType | null;
 }
 


### PR DESCRIPTION
Нужно в тагер SEO оперативный фикс сделать, надо добавить флаг какой включает поле однострочное новое (на третьем месте, после описания),
Keywords / Ключевые слова
По-умолчанию выключено, но мы будем делать где то его включенным